### PR TITLE
feat: Implementar menú lateral desplegable

### DIFF
--- a/src/components/SideMenu.astro
+++ b/src/components/SideMenu.astro
@@ -1,0 +1,80 @@
+---
+// src/components/SideMenu.astro
+---
+
+<div id="side-menu" class="side-menu">
+  <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
+  <a href="/paginas/juegos.html">Juegos</a>
+  <a>Aplicaciones</a>
+  <a>Sitios Web</a>
+  <a>Proyectos</a>
+</div>
+
+<style>
+  .side-menu {
+    height: 100%;
+    width: 0;
+    position: fixed;
+    z-index: 1001; /* Asegúrate de que sea mayor que el z-index del header */
+    top: 0;
+    left: 0;
+    background-color: #111;
+    overflow-x: hidden;
+    transition: 0.5s;
+    padding-top: 60px;
+  }
+
+  .side-menu a {
+    padding: 8px 8px 8px 32px;
+    text-decoration: none;
+    font-size: 25px;
+    color: #818181;
+    display: block;
+    transition: 0.3s;
+  }
+
+  .side-menu a:hover {
+    color: #f1f1f1;
+  }
+
+  .side-menu .closebtn {
+    position: absolute;
+    top: 0;
+    right: 25px;
+    font-size: 36px;
+    margin-left: 50px;
+  }
+</style>
+
+<script>
+  function openNav() {
+    const sideMenu = document.getElementById("side-menu");
+    if (sideMenu) {
+      sideMenu.style.width = "250px";
+    }
+  }
+
+  function closeNav() {
+    const sideMenu = document.getElementById("side-menu");
+    if (sideMenu) {
+      sideMenu.style.width = "0";
+    }
+  }
+
+  // Adjuntar openNav al botón del menú en navBar.astro
+  // Esto se hará en navBar.astro, pero la función está definida aquí
+  // para mantener la lógica del menú lateral junta.
+  // Considera mover esta lógica si prefieres mantenerla separada.
+  // document.addEventListener('DOMContentLoaded', () => {
+  //   const menuButton = document.getElementById('menu-button-placeholder'); // Este ID debe ser el del botón en navBar.astro
+  //   if (menuButton) {
+  //     menuButton.addEventListener('click', openNav);
+  //   }
+  // });
+
+  // Hacer las funciones openNav y closeNav globales para que puedan ser llamadas desde navBar.astro
+  if (typeof window !== 'undefined') {
+    (window as any).openNav = openNav;
+    (window as any).closeNav = closeNav;
+  }
+</script>

--- a/src/components/navBar.astro
+++ b/src/components/navBar.astro
@@ -13,10 +13,29 @@
     <a class="apartados"><p>Sitios Web</p></a>
     <a class="apartados"><p>proyectos</p></a>
   </div>
-  <label class="btn_menu" class="apartados" for="btn-menu"
-    ><img src="/icons/menu-01-stroke-rounded.svg" alt="" /></label
+  <label id="menu-button" class="btn_menu" class="apartados" for="btn-menu"
+    ><img src="/icons/menu-01-stroke-rounded.svg" alt="Abrir menú" /></label
   >
 </header>
+
+<script>
+  // Script para manejar la apertura del menú lateral
+  // Asegúrate de que SideMenu.astro está importado o sus funciones openNav/closeNav son globales
+  // y que el SideMenu tiene el id="side-menu"
+  const menuButton = document.getElementById('menu-button');
+  if (menuButton) {
+    menuButton.addEventListener('click', () => {
+      // Suponiendo que openNav está definida globalmente desde SideMenu.astro
+      // o que SideMenu.astro maneja su propia visibilidad basado en eventos.
+      // Para una integración más limpia, podrías usar custom events o un store.
+      if (typeof openNav === 'function') {
+        openNav();
+      } else {
+        console.error('La función openNav no está definida. Asegúrate de que SideMenu.astro se carga y define openNav globalmente o ajusta la lógica de eventos.');
+      }
+    });
+  }
+</script>
 
 <style>
   @font-face {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import NavBar from "../components/navBar.astro";
+import SideMenu from "../components/SideMenu.astro"; // Importar SideMenu
 ---
 
 <!doctype html>
@@ -17,6 +18,7 @@ import NavBar from "../components/navBar.astro";
   </head>
   <body>
     <NavBar />
+    <SideMenu /> <!-- Añadir SideMenu al layout -->
     <slot />
   </body>
 </html>


### PR DESCRIPTION
He añadido un componente de menú lateral (`SideMenu.astro`) que se activa mediante un botón en la barra de navegación (`navBar.astro`) en tamaños de pantalla más pequeños.

Principales cambios:
- Creación de `src/components/SideMenu.astro` con HTML, CSS y JavaScript para la funcionalidad del menú.
- Modificación de `src/components/navBar.astro` para incluir el botón de activación del menú y el script correspondiente.
- Actualización de `src/layouts/Layout.astro` para importar e incluir el componente `SideMenu`.
- Las funciones para abrir y cerrar el menú (`openNav`, `closeNav`) se han hecho globales para permitir la comunicación entre componentes.

El menú lateral replica las opciones de navegación de la barra principal y lo he probado visualmente en diferentes resoluciones de pantalla.